### PR TITLE
Removed manual step in installation of requirements

### DIFF
--- a/flask-app/mtw_requirements.txt
+++ b/flask-app/mtw_requirements.txt
@@ -10,8 +10,11 @@ diff_match_patch==20230430
 Flask==3.0.2
 Flask-Caching==2.1.0
 Flask-Paranoid==0.3.0
-#Flask-SeaSurf==1.1.1 # Broken with Flask 3+
-#Run: pip install https://github.com/maxcountryman/flask-seasurf/archive/refs/heads/main.zip
+# Flask-SeaSurf==1.1.1 is broken with Flask 3+
+# The last version of Flask-Seasurf on PyPi (v1.1.1) is outdated
+# We install from the last commit on GitHub instead
+# See: https://github.com/maxcountryman/flask-seasurf/issues/135
+Flask-SeaSurf @ https://github.com/maxcountryman/flask-seasurf/archive/refs/heads/main.tar.gz#sha256=64048ed1f01d6bf6ae369112eb70a21dcbbb6612eddd3a9069d8f49353c35400
 Flask-Session==0.6.0
 flask-talisman==1.1.0
 future==0.18.3


### PR DESCRIPTION
Manual install breaks automatic processes like Docker build, so it's better if we can automate it.

I'm still looking for a solution to make Windows dependencies optional, so they would not be installed in a linux env.