### PR TITLE
Potential fix for code scanning alert no. 37: Uncontrolled data used in path expression

### DIFF
--- a/flask-app/application/modules/utils.py
+++ b/flask-app/application/modules/utils.py
@@ -1370,7 +1370,15 @@ def getStatsFpath(stat, ext="json", params=None, target_year=None):
     if not target_year:
         target_year = app.config["TARGET_YEAR"]
 
-    return Path(app.config["EXP_DIR"], target_year + "_" + stat + "." + ext)
+    base_dir = Path(app.config["EXP_DIR"])
+    constructed_path = Path(base_dir, target_year + "_" + stat + "." + ext)
+    normalized_path = constructed_path.resolve()
+
+    # Ensure the path is within the allowed base directory
+    if not str(normalized_path).startswith(str(base_dir.resolve())):
+        raise ValueError("Invalid file path: Path traversal detected.")
+
+    return normalized_path
 
 
 def getLockFpath(stat):


### PR DESCRIPTION
Potential fix for [https://github.com/filak/MTW-MeSH/security/code-scanning/37](https://github.com/filak/MTW-MeSH/security/code-scanning/37)

To fix the issue, we need to validate and sanitize the file paths constructed from user-controlled input. Specifically:
1. Normalize the constructed path using `os.path.normpath` or `os.path.realpath` to remove any `..` segments or symbolic links.
2. Ensure that the normalized path starts with the intended base directory (`app.config["EXP_DIR"]`) to prevent path traversal attacks.
3. Raise an exception or return an error if the validation fails.

The changes will be made in the `getStatsFpath` function, as it is responsible for constructing the file path. This ensures that all downstream functions, including `writeJsonFile`, receive a validated path.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
